### PR TITLE
Resolve messages

### DIFF
--- a/lib/Publisher.js
+++ b/lib/Publisher.js
@@ -62,6 +62,8 @@ class Publisher extends EventEmitter {
     //  headers: extra headers to include
     //  subscriber_listener: callback for new subscribers connect/disconnect
 
+    this._resolve = !!options.resolve;
+
     this._lastSentMsg = null;
 
     this._nodeHandle = nodeHandle;
@@ -146,9 +148,10 @@ class Publisher extends EventEmitter {
     this._pubTime = Date.now();
     msgQueue.forEach((msg) => {
       try {
-        // serialize pushes buffers onto buffInfo.buffer in order
-        // concat them, and preprend the byte length to the message
-        // before sending
+        if (this._resolve) {
+          msg = this._messageHandler.Resolve(msg);
+        }
+
         const serializedMsg = TcprosUtils.serializeMessage(this._messageHandler, msg);
 
         Object.keys(this._subClients).forEach((client) => {
@@ -163,7 +166,7 @@ class Publisher extends EventEmitter {
         }
       }
       catch (err) {
-        this._log.warn('Error when publishing message on topic %s: %s', this.getTopic(), err.stack);
+        this._log.error('Error when publishing message on topic %s: %s', this.getTopic(), err.stack);
       }
     });
   }

--- a/lib/ServiceClient.js
+++ b/lib/ServiceClient.js
@@ -63,6 +63,8 @@ class ServiceClient extends EventEmitter {
 
     this._maxQueueLength = options.queueLength || -1;
 
+    this._resolve = !!options.resolve;
+
     this._calling = false;
 
     this._log = Logging.getLogger('ros.rosnodejs');
@@ -178,6 +180,10 @@ class ServiceClient extends EventEmitter {
   }
 
   _sendRequest(call) {
+    if (this._resolve) {
+      call.request = this._messageHandler.Request.Resolve(call.request);
+    }
+
     // serialize request
     const serializedRequest = TcprosUtils.serializeMessage(this._messageHandler.Request, call.request);
 

--- a/utils/ClientStates.js
+++ b/utils/ClientStates.js
@@ -1,0 +1,5 @@
+module.exports = {
+  REGISTERING: Symbol('rosnodejs.clientRegistering'),
+  REGISTERED: Symbol('rosnodejs.clientRegistered'),
+  SHUTDOWN: Symbol('rosnodejs.clientShutdown')
+};

--- a/utils/GlobalSpinner.js
+++ b/utils/GlobalSpinner.js
@@ -139,7 +139,7 @@ class GlobalSpinner extends events {
   _queueMessage(clientId, message) {
     const clientQueue = this._clientQueueMap.get(clientId);
     if (!clientQueue) {
-      throw new Error('Unable to queue message for unknown client');
+      throw new Error(`Unable to queue message for unknown client ${clientId}`);
     }
     // else
     if (clientQueue.length === 0) {


### PR DESCRIPTION
Adds code to generated messages to optionally resolve complex message fields. We don't purposefully protect users from setting invalid primitive fields (the message they provide has an int where a string should be) but will create default values if those fields are missing. Message resolution is deep so if your message has a defined message within it we also resolve that message.

Adds tests for these cases.

Built on #2 
