### PR TITLE
Shutdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,6 +145,10 @@ let Rosnodejs = {
       });
   },
 
+  reset() {
+    rosNode = null;
+  },
+
   loadPackage(packageName, outputDir=null, verbose=false) {
     const msgLoader = new MsgLoader(verbose);
     if (!outputDir) {

--- a/lib/Logging.js
+++ b/lib/Logging.js
@@ -47,7 +47,7 @@ const KNOWN_LOGS = [
   },
   {
     name: `${DEFAULT_LOGGER_NAME}.spinner`,
-    level: 'info'
+    level: 'error'
   }
 ];
 

--- a/lib/Logging.js
+++ b/lib/Logging.js
@@ -118,6 +118,10 @@ class LoggingManager {
   }
 
   initializeRosOptions(rosnodejs, options={}) {
+    if (options.skipRosLogging) {
+      return Promise.resolve();
+    }
+
     const nh = rosnodejs.nh;
     let rosLogStream;
     try {
@@ -145,7 +149,7 @@ class LoggingManager {
       this.rootLogger.warn('Unable to setup ros logging services');
     }
 
-    if (rosLogStream && !options.testing) {
+    if (rosLogStream && options.waitOnRosOut !== undefined && options.waitOnRosOut) {
       this.rootLogger.debug('Waiting for /rosout connection before resolving node initialization...');
       return new Promise((resolve,reject) => {
         rosLogStream.getPub().on('connection', () => {

--- a/lib/Publisher.js
+++ b/lib/Publisher.js
@@ -241,6 +241,11 @@ class Publisher extends EventEmitter {
   _register() {
     this._nodeHandle.registerPublisher(this._topic, this._type)
     .then((resp) => {
+      // if we were shutdown between the starting the registration and now, bail
+      if (this.isShutdown()) {
+        return;
+      }
+
       this._log.info('Registered %s as a publisher: %j', this._topic, resp);
       let code = resp[0];
       let msg = resp[1];

--- a/lib/Publisher.js
+++ b/lib/Publisher.js
@@ -17,11 +17,12 @@
 
 "use strict";
 
-let SerializationUtils = require('../utils/serialization_utils.js');
-let Serialize = SerializationUtils.Serialize;
-let TcprosUtils = require('../utils/tcpros_utils.js');
-let EventEmitter = require('events');
-let Logging = require('./Logging.js');
+const SerializationUtils = require('../utils/serialization_utils.js');
+const Serialize = SerializationUtils.Serialize;
+const TcprosUtils = require('../utils/tcpros_utils.js');
+const EventEmitter = require('events');
+const Logging = require('./Logging.js');
+const {REGISTERING, REGISTERED, SHUTDOWN} = require('../utils/ClientStates.js');
 
 class Publisher extends EventEmitter {
   constructor(options, nodeHandle) {
@@ -55,8 +56,6 @@ class Publisher extends EventEmitter {
     else {
       this._throttleMs = 0;
     }
-    this._pubTimeout = null;
-    this._pubTime = null;
 
     // OPTIONS STILL NOT HANDLED:
     //  headers: extra headers to include
@@ -71,12 +70,11 @@ class Publisher extends EventEmitter {
 
     this._log = Logging.getLogger('ros.rosnodejs');
 
-    this._ready = false;
-
     this._subClients = {};
 
     this._messageHandler = options.typeClass;
 
+    this._state = REGISTERING;
     this._register();
   }
 
@@ -104,11 +102,16 @@ class Publisher extends EventEmitter {
     this._nodeHandle.unadvertise(this.getTopic());
   }
 
+  isShutdown() {
+    return this._state === SHUTDOWN;
+  }
+
   disconnect() {
+    this._state = SHUTDOWN;
+
     Object.keys(this._subClients).forEach((clientId) => {
       const client = this._subClients[clientId];
       client.end();
-      client.destroy();
     });
 
     // disconnect from the spinner in case we have any pending callbacks
@@ -123,12 +126,16 @@ class Publisher extends EventEmitter {
    * @param [throttleMs] {number} optional override for publisher setting
    */
   publish(msg, throttleMs) {
+    if (this.isShutdown()) {
+      return;
+    }
+
     if (typeof throttleMs !== 'number') {
       throttleMs = this._throttleMs;
     }
 
     if (throttleMs < 0) {
-      // short circuit JS event queue, publish synchronously
+      // short circuit JS event queue, publish "synchronously"
       this._handleMsgQueue([msg]);
     }
     else {
@@ -140,12 +147,18 @@ class Publisher extends EventEmitter {
    * Pulls all msgs off queue, serializes, and publishes them
    */
   _handleMsgQueue(msgQueue) {
+
+    // There's a small chance that we were shutdown while the spinner was locked
+    // which could cause _handleMsgQueue to be called if this publisher was in there.
+    if (this.isShutdown()) {
+      return;
+    }
+
     const numClients = this.getNumSubscribers();
     if (numClients === 0) {
       this._log.debugThrottle(2000, `Publishing message on ${this.getTopic()} with no subscribers`);
     }
 
-    this._pubTime = Date.now();
     msgQueue.forEach((msg) => {
       try {
         if (this._resolve) {
@@ -234,13 +247,12 @@ class Publisher extends EventEmitter {
       let subs = resp[2];
       if (code === 1) {
         // registration worked
-        this._ready = true;
+        this._state = REGISTERED;
         this.emit('registered');
       }
     })
-    .catch((err, resp) => {
-      this._log.error('reg pub err ' + err + ' resp: '
-                      + JSON.stringify(resp));
+    .catch((err) => {
+      this._log.error('Error while registering publisher %s: %s', this.getTopic(), err);
     })
   }
 }

--- a/lib/RosNode.js
+++ b/lib/RosNode.js
@@ -154,9 +154,7 @@ class RosNode extends EventEmitter {
     const server = this._services[service];
     if (server) {
       this._debugLog.info('Unadvertising service %s', service);
-      // FIXME: we'll definitely need this when we support
-      // persistent service connections.
-      // service.disconnect();
+      server.disconnect();
       this.unregisterService(service, server.getServiceUri());
       delete this._services[service];
     }

--- a/lib/RosNode.js
+++ b/lib/RosNode.js
@@ -362,7 +362,9 @@ class RosNode extends EventEmitter {
               pub.handleSubscriberConnection(connection, header);
             }
             else {
-              this._log.warn('Got connection header for unknown topic %s', topic);
+              // presumably this just means we shutdown the publisher after this
+              // subscriber started trying to connect to us
+              this._log.info('Got connection header for unknown topic %s', topic);
             }
           }
           else if (header.hasOwnProperty('service')) {
@@ -446,7 +448,7 @@ class RosNode extends EventEmitter {
     if (sub) {
       this._debugLog.info('Got sub for topic ' + topic);
       let pubs = params[2];
-      sub.requestTopicFromPubs(params[2]);
+      sub._handlePublisherUpdate(params[2]);
       let resp = [
         1,
         'Handled publisher update for topic ' + topic,

--- a/lib/ServiceClient.js
+++ b/lib/ServiceClient.js
@@ -28,6 +28,7 @@ let Serialize = SerializationUtils.Serialize;
 let TcprosUtils = require('../utils/tcpros_utils.js');
 let EventEmitter = require('events');
 let Logging = require('./Logging.js');
+const {REGISTERED, SHUTDOWN} = require('../utils/ClientStates.js');
 
 /**
  * @class ServiceCall
@@ -76,6 +77,10 @@ class ServiceClient extends EventEmitter {
     this._serviceClient = null;
 
     this._callQueue = [];
+
+    this._currentCall = null;
+
+    this._state = REGISTERED;
   };
 
   getService() {
@@ -99,6 +104,17 @@ class ServiceClient extends EventEmitter {
     if (!this.isCallInProgress()) {
       this._serviceClient = null;
     }
+  }
+
+  shutdown() {
+    this._state = SHUTDOWN;
+    if (this._currentCall) {
+      this._currentCall.reject('SHUTDOWN');
+    }
+  }
+
+  isShutdown() {
+    return this._state === SHUTDOWN;
   }
 
   /**
@@ -127,33 +143,54 @@ class ServiceClient extends EventEmitter {
   }
 
   _executeCall() {
-    if (this._callQueue.length === 0) {
+    if (this.isShutdown()) {
+      return;
+    }
+    else if (this._callQueue.length === 0) {
       this._log.warn('Tried executing service call on empty queue');
       return;
     }
     // else
     const call = this._callQueue.shift();
+    this._currentCall = call;
     this._calling = true;
 
     this._initiateServiceConnection(call)
     .then(() => {
+      this._throwIfShutdown();
+
       return this._sendRequest(call);
     })
     .then((msg) => {
+      this._throwIfShutdown();
+
       this._calling = false;
+      this._currentCall = null;
+
       this._scheduleNextCall();
+
       call.resolve(msg);
     })
     .catch((err) => {
-      this._log.error(`Error during service ${this.getService()} call ${err.stack}`);
-      this._calling = false;
-      this._scheduleNextCall();
-      call.reject(err);
+      if (!this.isShutdown()) {
+        // this probably just means the service didn't exist yet - don't complain about it
+        // We should still reject the call
+        if (err.code !== 'EROSAPIERROR') {
+          this._log.error(`Error during service ${this.getService()} call ${err}`);
+        }
+
+        this._calling = false;
+        this._currentCall = null;
+
+        this._scheduleNextCall();
+
+        call.reject(err);
+      }
     });
   }
 
   _scheduleNextCall() {
-    if (this._callQueue.length > 0) {
+    if (this._callQueue.length > 0 && !this.isShutdown()) {
       process.nextTick(this._executeCall.bind(this));
     }
   }
@@ -165,12 +202,14 @@ class ServiceClient extends EventEmitter {
     if (!this.getPersist() || this._serviceClient === null) {
       return this._nodeHandle.lookupService(this.getService())
       .then((resp) => {
+        this._throwIfShutdown();
+
         const serviceUri = resp[2];
         const serviceHost = NetworkUtils.getAddressAndPortFromUri(serviceUri);
 
         // connect to the service's tcpros server
         return this._connectToService(serviceHost, call);
-      });
+      })
     }
     else {
       // this is a persistent service that we've already set up
@@ -209,40 +248,10 @@ class ServiceClient extends EventEmitter {
     return new Promise((resolve, reject) => {
       this._log.debug('Service client %s connecting to %j', this.getService(), serviceHost);
 
-      // create a socket connection to the service provider
-      call.serviceClient = net.connect(serviceHost, () => {
+      this._createCallSocketAndHandlers(serviceHost, call, reject);
 
-        // Connection to service's TCPROS server succeeded - generate and send a connection header
-        this._log.debug('Sending service client %s connection header', this.getService());
+      this._cacheSocketIfPersistent(call);
 
-        let serviceClientHeader = TcprosUtils.createServiceClientHeader(this._nodeHandle.getNodeName(),
-          this.getService(), this._messageHandler.md5sum(), this.getType(), this.getPersist());
-
-        call.serviceClient.write(serviceClientHeader);
-      });
-
-      // If this is a persistent service client, we're here because we haven't connected to this service before.
-      // Cache the service client for later use. Future calls won't need to lookup the service with the ROS master
-      // or deal with the connection header.
-      if (this.getPersist()) {
-        this._serviceClient = call.serviceClient;
-      }
-
-      // bind a close handling function
-      call.serviceClient.on('close', () => {
-        call.serviceClient = null;
-        // we could probably just always reset this._serviceClient to null here but...
-        if (this.getPersist()) {
-          this._serviceClient = null;
-        }
-      });
-
-      // bind an error function - any errors connecting to the service
-      // will cause the call to be rejected (in this._executeCall)
-      call.serviceClient.on('error', (err) => {
-        this._log.info(`Service Client ${this.getService()} error: ${err}`);
-        reject(err);
-      });
 
       let deserializer = new DeserializeStream();
       call.serviceClient.$deserializeStream = deserializer;
@@ -263,6 +272,51 @@ class ServiceClient extends EventEmitter {
         }
       });
     });
+  }
+
+  _createCallSocketAndHandlers(serviceHost, call, reject) {
+    // create a socket connection to the service provider
+    call.serviceClient = net.connect(serviceHost, () => {
+
+      // Connection to service's TCPROS server succeeded - generate and send a connection header
+      this._log.debug('Sending service client %s connection header', this.getService());
+
+      let serviceClientHeader = TcprosUtils.createServiceClientHeader(this._nodeHandle.getNodeName(),
+        this.getService(), this._messageHandler.md5sum(), this.getType(), this.getPersist());
+
+      call.serviceClient.write(serviceClientHeader);
+    });
+
+    // bind a close handling function
+    call.serviceClient.on('close', () => {
+      call.serviceClient = null;
+      // we could probably just always reset this._serviceClient to null here but...
+      if (this.getPersist()) {
+        this._serviceClient = null;
+      }
+    });
+
+    // bind an error function - any errors connecting to the service
+    // will cause the call to be rejected (in this._executeCall)
+    call.serviceClient.on('error', (err) => {
+      this._log.info(`Service Client ${this.getService()} error: ${err}`);
+      reject(err);
+    });
+  }
+
+  _cacheSocketIfPersistent(call) {
+    // If this is a persistent service client, we're here because we haven't connected to this service before.
+    // Cache the service client for later use. Future calls won't need to lookup the service with the ROS master
+    // or deal with the connection header.
+    if (this.getPersist()) {
+      this._serviceClient = call.serviceClient;
+    }
+  }
+
+  _throwIfShutdown() {
+    if (this.isShutdown()) {
+      throw new Error('SHUTDOWN');
+    }
   }
 }
 

--- a/lib/ServiceClient.js
+++ b/lib/ServiceClient.js
@@ -80,6 +80,9 @@ class ServiceClient extends EventEmitter {
 
     this._currentCall = null;
 
+    // ServiceClients aren't "registered" anywhere but it's not
+    // waiting to get registered either so REGISTERING doesn't make sense...
+    // Hence, we'll just call it REGISTERED.
     this._state = REGISTERED;
   };
 

--- a/lib/ServiceServer.js
+++ b/lib/ServiceServer.js
@@ -17,17 +17,18 @@
 
 "use strict";
 
-let net = require('net');
-let NetworkUtils = require('../utils/network_utils.js');
+const net = require('net');
+const NetworkUtils = require('../utils/network_utils.js');
 const ros_msg_utils = require('ros_msg_utils');
 const base_serializers = ros_msg_utils.Serialize;
-let SerializationUtils = require('../utils/serialization_utils.js');
-let DeserializeStream = SerializationUtils.DeserializeStream;
-let Deserialize = SerializationUtils.Deserialize;
-let Serialize = SerializationUtils.Serialize;
-let TcprosUtils = require('../utils/tcpros_utils.js');
-let EventEmitter = require('events');
-let Logging = require('./Logging.js');
+const SerializationUtils = require('../utils/serialization_utils.js');
+const DeserializeStream = SerializationUtils.DeserializeStream;
+const Deserialize = SerializationUtils.Deserialize;
+const Serialize = SerializationUtils.Serialize;
+const TcprosUtils = require('../utils/tcpros_utils.js');
+const EventEmitter = require('events');
+const Logging = require('./Logging.js');
+const {REGISTERING, REGISTERED, SHUTDOWN} = require('../utils/ClientStates.js');
 
 class ServiceServer extends EventEmitter {
   constructor(options, callback, nodeHandle) {
@@ -47,6 +48,8 @@ class ServiceServer extends EventEmitter {
     this._messageHandler = options.typeClass;
 
     this._clients = {};
+
+    this._state = REGISTERING;
 
     this._register();
   };
@@ -71,13 +74,28 @@ class ServiceServer extends EventEmitter {
     return NetworkUtils.formatServiceUri(this._port);
   }
 
+  /**
+   * The ROS client shutdown code is a little noodly. Users can close a client through
+   * the ROS node or the client itself and both are correct. Either through a node.unadvertise()
+   * call or a client.shutdown() call - in both instances a call needs to be made to the ROS master
+   * and the client needs to tear itself down.
+   */
   shutdown() {
     this._nodeHandle.unadvertiseService(this.getService());
   }
 
+  isShutdown() {
+    return this._state === SHUTDOWN;
+  }
+
   disconnect() {
+    this._state = SHUTDOWN;
+
     Object.keys(this._clients).forEach((clientId) => {
       const client = this._clients[clientId];
+
+      client.$deserializeStream.removeAllListeners();
+
       client.end();
       client.destroy();
     });
@@ -115,6 +133,7 @@ class ServiceServer extends EventEmitter {
     });
 
     this._clients[client.name] = client;
+    this.emit('connection', header, client.name);
   }
 
   _handleMessage(client, data) {
@@ -145,6 +164,12 @@ class ServiceServer extends EventEmitter {
   _register() {
     this._nodeHandle.registerService(this.getService())
     .then((resp) => {
+      // if we were shutdown between the starting the registration and now, bail
+      if (this.isShutdown()) {
+        return;
+      }
+
+      this._state = REGISTERED;
       this.emit('registered');
     });
   }

--- a/lib/ServiceServer.js
+++ b/lib/ServiceServer.js
@@ -46,6 +46,8 @@ class ServiceServer extends EventEmitter {
 
     this._messageHandler = options.typeClass;
 
+    this._clients = {};
+
     this._register();
   };
 
@@ -67,6 +69,20 @@ class ServiceServer extends EventEmitter {
 
   getServiceUri() {
     return NetworkUtils.formatServiceUri(this._port);
+  }
+
+  shutdown() {
+    this._nodeHandle.unadvertiseService(this.getService());
+  }
+
+  disconnect() {
+    Object.keys(this._clients).forEach((clientId) => {
+      const client = this._clients[clientId];
+      client.end();
+      client.destroy();
+    });
+
+    this._clients = {};
   }
 
   handleClientConnection(client, header) {
@@ -94,8 +110,11 @@ class ServiceServer extends EventEmitter {
     client.$deserializeStream.on('message', client.$messageHandler);
 
     client.on('close', () => {
+      delete this._clients[client.name];
       this._log.debug('Service client %s disconnected!', client.name);
     });
+
+    this._clients[client.name] = client;
   }
 
   _handleMessage(client, data) {
@@ -119,6 +138,7 @@ class ServiceServer extends EventEmitter {
     if (!client.$persist) {
       this._log.debug('Closing non-persistent client');
       client.end();
+      delete this._clients[client.name];
     }
   }
 

--- a/lib/Subscriber.js
+++ b/lib/Subscriber.js
@@ -17,17 +17,18 @@
 
 "use strict";
 
-let NetworkUtils = require('../utils/network_utils.js');
-let SerializationUtils = require('../utils/serialization_utils.js');
-let DeserializeStream = SerializationUtils.DeserializeStream;
-let Deserialize =  SerializationUtils.Deserialize;
-let Serialize = SerializationUtils.Serialize;
-let TcprosUtils = require('../utils/tcpros_utils.js');
-let Socket = require('net').Socket;
-let EventEmitter = require('events');
-let Logging = require('./Logging.js');
+const NetworkUtils = require('../utils/network_utils.js');
+const SerializationUtils = require('../utils/serialization_utils.js');
+const DeserializeStream = SerializationUtils.DeserializeStream;
+const Deserialize =  SerializationUtils.Deserialize;
+const Serialize = SerializationUtils.Serialize;
+const TcprosUtils = require('../utils/tcpros_utils.js');
+const Socket = require('net').Socket;
+const EventEmitter = require('events');
+const Logging = require('./Logging.js');
+const {REGISTERING, REGISTERED, SHUTDOWN} = require('../utils/ClientStates.js');
 
-let protocols = [['TCPROS']];
+const protocols = [['TCPROS']];
 
 //-----------------------------------------------------------------------
 
@@ -68,20 +69,14 @@ class Subscriber extends EventEmitter {
 
     this._messageHandler = options.typeClass;
 
-    this._ready = false;
-
     this._msgQueue = [];
 
     this._pubClients = {};
 
-    /**
-     * map of node uris we requested connections from
-     */
     this._nodeMap = {};
 
+    this._state = REGISTERING;
     this._register();
-
-    this._deserializer = new DeserializeStream();
   }
 
   _getSpinnerId() {
@@ -101,7 +96,12 @@ class Subscriber extends EventEmitter {
   }
 
   shutdown() {
+    this._log.debug('Shutting down subscriber %s', this.getTopic());
     this._nodeHandle.unsubscribe(this.getTopic());
+  }
+
+  isShutdown() {
+    return this._state === SHUTDOWN;
   }
 
   /**
@@ -109,18 +109,51 @@ class Subscriber extends EventEmitter {
    * @param pubs {Array} array of uris of nodes that are publishing this topic
    */
   requestTopicFromPubs(pubs) {
-    // filter out any uris we have already connected to
-    pubs = pubs.filter((pubUri) => {
-      return !this._nodeMap.hasOwnProperty(pubUri.trim());
-    });
     pubs.forEach((pubUri) => {
-      // pull the ip address and port from the publisher uri
       pubUri = pubUri.trim();
-      this._nodeMap[pubUri] = 1;
-      let info = NetworkUtils.getAddressAndPortFromUri(pubUri);
-      // send a topic request to the publisher's node
-      this._log.debug('Sending topic request to ' + JSON.stringify(info));
-      this._nodeHandle.requestTopic(info.host, info.port, this._topic, protocols)
+      this._requestTopicFromPublisher(pubUri);
+    });
+  }
+
+  disconnect() {
+    this._state = SHUTDOWN;
+
+    Object.keys(this._pubClients).forEach(this._disconnectClient.bind(this));
+
+    // disconnect from the spinner in case we have any pending callbacks
+    this._nodeHandle.getSpinner().disconnect(this._getSpinnerId());
+    this._pubClients = {};
+  }
+
+  /**
+   * Handle an update from the ROS master with the list of current publishers. Connect to any new ones
+   * and disconnect from any not included in the list.
+   * @param publisherList [Array.string]
+   * @private
+   */
+  _handlePublisherUpdate(publisherList) {
+    const missingPublishers = new Set(Object.keys(this._pubClients));
+
+    publisherList.forEach((pubUri) => {
+      pubUri = pubUri.trim();
+      if (!this._pubClients.hasOwnProperty(pubUri)) {
+        this._requestTopicFromPublisher(pubUri);
+      }
+
+      missingPublishers.delete(pubUri);
+    });
+
+    missingPublishers.forEach((pubUri) => {
+      this._disconnectClient(pubUri);
+    });
+  }
+
+  _requestTopicFromPublisher(pubUri) {
+    this._nodeMap[pubUri] = 1;
+    let info = NetworkUtils.getAddressAndPortFromUri(pubUri);
+    // send a topic request to the publisher's node
+    this._log.debug('Sending topic request to ' + JSON.stringify(info));
+    this._nodeHandle.requestTopic(info.host, info.port, this._topic, protocols)
       .then((resp) => {
         this._handleTopicRequestResponse(resp, pubUri);
       })
@@ -129,29 +162,40 @@ class Subscriber extends EventEmitter {
         this._log.warn('Error requesting topic on %s: %s, %s', this.getTopic(), err, resp);
         delete this._nodeMap[pubUri];
       });
-    });
   }
 
-  disconnect() {
-    Object.keys(this._pubClients).forEach((clientId) => {
-      const client = this._pubClients[clientId];
-      client.end();
-      client.destroy();
-    });
+  _disconnectClient(clientId) {
+    const client = this._pubClients[clientId];
+    this._log.debug('Disconnecting client %s', clientId);
+    client.end();
 
-    // disconnect from the spinner in case we have any pending callbacks
-    this._nodeHandle.getSpinner().disconnect(this._getSpinnerId());
-    this._pubClients = {};
+    client.$deserializer.removeAllListeners();
+
+    client.$deserializer.end();
+    client.unpipe(client.$deserializer);
+
+    delete client.$deserializer;
+    delete client.$boundMessageHandler;
+
+    delete this._pubClients[clientId];
   }
 
   _register() {
     this._nodeHandle.registerSubscriber(this._topic, this._type)
     .then((resp) => {
-      // handle response from register subscriber call
+      // if we were shutdown between the starting the registration and now, bail
+      if (this.isShutdown()) {
+        return;
+      }
+
+      // else handle response from register subscriber call
       let code = resp[0];
       let msg = resp[1];
       let pubs = resp[2];
       if ( code === 1 ) {
+        // success! update state to reflect that we're registered
+        this._state = REGISTERED;
+
         if (pubs.length > 0) {
           // this means we're ok and that publishers already exist on this topic
           // we should connect to them
@@ -169,6 +213,10 @@ class Subscriber extends EventEmitter {
    * @param resp {Array} xmlrpc response to a topic request
    */
   _handleTopicRequestResponse(resp, nodeUri) {
+    if (this.isShutdown()) {
+      return;
+    }
+
     this._log.debug('Topic request response: ' + JSON.stringify(resp));
     let info = resp[2];
     let port = info[2];
@@ -185,12 +233,23 @@ class Subscriber extends EventEmitter {
     });
 
     client.connect(port, address, () => {
+      if (this.isShutdown()) {
+        client.end();
+        return;
+      }
+
       this._log.debug('Subscriber on ' + this.getTopic() + ' connected to publisher at ' + address + ':' + port);
       client.write(this._createTcprosHandshake());
+
+      this._pubClients[client.nodeUri] = client;
     });
 
-    client.$boundMessageHandler = this._handleMessage.bind(this, client);
+
     let deserializer = new DeserializeStream();
+
+    client.$boundMessageHandler = this._handleMessage.bind(this, client);
+    client.$deserializer = deserializer;
+
     client.pipe(deserializer);
     deserializer.on('message', client.$boundMessageHandler);
   }
@@ -201,6 +260,7 @@ class Subscriber extends EventEmitter {
 
   _handleMessage(client, msg) {
     if (!client.$initialized) {
+
       let header = TcprosUtils.parseTcpRosHeader(msg);
       // check if the publisher had a problem with our connection header
       if (header.error) {
@@ -216,8 +276,8 @@ class Subscriber extends EventEmitter {
         client.end(Serialize(error));
         return;
       }
+
       this._log.debug('Subscriber ' + this.getTopic() + ' got connection header ' + JSON.stringify(header));
-      this._pubClients[client.name] = client;
       client.$initialized = true;
 
       this.emit('connection', header, client.name);
@@ -225,8 +285,7 @@ class Subscriber extends EventEmitter {
       client.on('close', () => {
         this._log.info('Pub %s closed on topic %s', client.name, this.getTopic());
         this._log.debug('Subscriber ' + this.getTopic() + ' client ' + client.name + ' disconnected!');
-        delete this._nodeMap[client.nodeUri];
-        delete this._pubClients[client.name];
+        delete this._pubClients[client.nodeUri];
 
         this.emit('disconnect')
       });

--- a/lib/Subscriber.js
+++ b/lib/Subscriber.js
@@ -69,11 +69,7 @@ class Subscriber extends EventEmitter {
 
     this._messageHandler = options.typeClass;
 
-    this._msgQueue = [];
-
     this._pubClients = {};
-
-    this._nodeMap = {};
 
     this._state = REGISTERING;
     this._register();
@@ -149,7 +145,6 @@ class Subscriber extends EventEmitter {
   }
 
   _requestTopicFromPublisher(pubUri) {
-    this._nodeMap[pubUri] = 1;
     let info = NetworkUtils.getAddressAndPortFromUri(pubUri);
     // send a topic request to the publisher's node
     this._log.debug('Sending topic request to ' + JSON.stringify(info));
@@ -160,7 +155,6 @@ class Subscriber extends EventEmitter {
       .catch((err, resp) => {
         // there was an error in the topic request
         this._log.warn('Error requesting topic on %s: %s, %s', this.getTopic(), err, resp);
-        delete this._nodeMap[pubUri];
       });
   }
 
@@ -291,10 +285,6 @@ class Subscriber extends EventEmitter {
       });
     }
     else {
-      // deserialize message
-      // deserialization returns object {data: <msg>, buffer: <remaining buffer after deserialization>}
-      // remaining buffer should be empty
-      // data should be your entire message
       if (this._throttleMs < 0) {
         this._handleMsgQueue([msg]);
       }
@@ -313,9 +303,6 @@ class Subscriber extends EventEmitter {
         this._log.warn('Error while dispatching message ' + err);
       }
     });
-
-    // clear out queue
-    this._msgQueue = [];
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   ],
   "scripts": {
     "test": "mocha test/directory.js",
-    "gennodejsTest": "mocha test/gennodejsTest",
+    "gennodejsTest": "mocha test/gennodejsTest.js",
+    "stressTest": "mocha test/stress.js",
     "flatten": "node tools/flatten.js",
     "generate": "node tools/generateMessages.js"
   },

--- a/test/ClientShutdown.js
+++ b/test/ClientShutdown.js
@@ -1,0 +1,357 @@
+
+const chai = require('chai');
+const xmlrpc = require('xmlrpc');
+const rosnodejs = require('rosnodejs');
+
+const TOPIC = '/topic';
+const TYPE = 'std_msgs/String';
+const SERVICE = '/service';
+const SRV = 'std_srvs/Empty';
+
+const MASTER_PORT = 11234;
+
+// Each Test in this suite simulates rapid fire connection/disconnection
+// of TCPROS clients
+describe('ClientShutdown', function() {
+
+  this.timeout(10000);
+  this.slow(10000);
+
+  let sub = null;
+  let pub = null;
+  let service = null;
+  let client = null;
+
+  let interval1;
+  let interval2;
+  let interval3;
+
+  let masterStub;
+
+  function startSub(nh) {
+    sub = nh.subscribe(TOPIC, TYPE, (msg) => {
+      console.log('%j', msg);
+    });
+
+    return sub;
+  }
+
+  function stopSub() {
+    if (sub) {
+      sub.shutdown();
+      sub = null;
+    }
+  }
+
+  function startPub(nh) {
+    pub = nh.advertise(TOPIC, TYPE);
+    return pub;
+  }
+
+  function stopPub() {
+    if (pub) {
+      pub.shutdown();
+      pub = null;
+    }
+  }
+
+  function startService(nh) {
+    service = nh.advertiseService(SERVICE, SRV, () => {
+      console.log('handling service call');
+      return true;
+    });
+    return service;
+  }
+
+  function stopService() {
+    if (service) {
+      service.shutdown();
+      service = null;
+    }
+  }
+
+  function startClient(nh) {
+    client = nh.serviceClient(SERVICE, SRV);
+    return client;
+  }
+
+  function stopClient() {
+    if (client) {
+      client.shutdown();
+      client = null;
+    }
+  }
+
+  before((done) => {
+    masterStub = xmlrpc.createServer({host: 'localhost', port: MASTER_PORT}, () => { done(); });
+  });
+
+  after((done) => {
+    masterStub.close(() => { done(); });
+  });
+
+  beforeEach(() => {
+    let pubInfo = null;
+    let subInfo = null;
+    let serviceInfo = null;
+
+    masterStub.on('getUri', (err, params, callback) => {
+      const resp = [ 1, '', 'localhost:11311/' ];
+      callback(null, resp);
+    });
+
+    masterStub.on('registerSubscriber', (err, params, callback) => {
+      subInfo = params[3];
+      // console.log('sub reg ' + params);
+      //console.log(pubInfo);
+
+      const resp =  [1, 'You did it!', []];
+      if (pubInfo) {
+        resp[2].push(pubInfo);
+      }
+      callback(null, resp);
+    });
+
+    masterStub.on('unregisterSubscriber', (err, params, callback) => {
+      // console.log('unregister subscriber!');
+      const resp =  [1, 'You did it!', subInfo ? 1 : 0];
+      callback(null, resp);
+      subInfo = null;
+    });
+
+    masterStub.on('registerPublisher', (err, params, callback) => {
+      // console.log('pub reg ' + Date.now());
+      pubInfo = params[3];
+      const resp =  [1, 'You did it!', []];
+      if (subInfo) {
+        resp[2].push(pubInfo);
+        let subAddrParts = subInfo.replace('http://', '').split(':');
+        let client = xmlrpc.createClient({host: subAddrParts[0], port: subAddrParts[1]});
+        let data = [1, TOPIC, [pubInfo]];
+        client.methodCall('publisherUpdate', data, (err, response) => { });
+      }
+      callback(null, resp);
+    });
+
+    masterStub.on('unregisterPublisher', (err, params, callback) => {
+      // console.log('pub unreg ' + Date.now());
+      const resp =  [1, 'You did it!', pubInfo ? 1 : 0];
+      callback(null, resp);
+      if (subInfo) {
+        let subAddrParts = subInfo.replace('http://', '').split(':');
+        let client = xmlrpc.createClient({host: subAddrParts[0], port: subAddrParts[1]});
+        let data = [1, TOPIC, []];
+        client.methodCall('publisherUpdate', data, (err, response) => { });
+      }
+      pubInfo = null;
+    });
+
+    masterStub.on('registerService', (err, params, callback) => {
+      serviceInfo = params[2];
+
+      const resp = [1, 'You did it!', []];
+      callback(null, resp);
+    });
+
+    masterStub.on('unregisterService', (err, params, callback) => {
+      const resp = [1, 'You did it!', subInfo ? 1 : 0];
+      callback(null, resp);
+      serviceInfo = null;
+    });
+
+    masterStub.on('lookupService', (err, params, callback) => {
+      if (serviceInfo) {
+        const resp = [1, "you did it", serviceInfo];
+        callback(null, resp);
+      }
+      else {
+        const resp = [-1, "no provider", ""];
+        callback(null, resp);
+      }
+    });
+
+    masterStub.on('NotFound', (method, params) => {
+      console.error('Got unknown method call %s: %j', method, params);
+    });
+
+    return rosnodejs.initNode('/my_node', {rosMasterUri: `http://localhost:${MASTER_PORT}`, logging: {testing: true}});
+  });
+
+  afterEach(() => {
+    sub = null;
+    pub = null;
+    service = null;
+    client = null;
+
+    clearInterval(interval1);
+    clearInterval(interval2);
+    clearInterval(interval3);
+
+    const nh = rosnodejs.nh;
+
+    // clear out any service, subs, pubs
+    nh._node._services = {};
+    nh._node._subscribers = {};
+    nh._node._publishers = {};
+
+    // remove any master api handlers we set up
+    masterStub.removeAllListeners();
+  });
+
+  it('Subscriber Shutdown', (done) => {
+    const nh = rosnodejs.nh;
+    const pub = startPub(nh);
+
+    const msg = {data: 'This shouldn\'t crash'};
+
+    interval1 = setInterval(() => {
+      pub.publish(msg);
+    }, 3);
+
+    interval2 = setInterval(() => {
+      if (sub === null) {
+        startSub(nh);
+      }
+      else {
+        stopSub();
+      }
+    }, 10);
+
+    setTimeout(done, 8000);
+  });
+
+  it('Publisher Shutdown', (done) => {
+    const nh = rosnodejs.nh;
+    startSub(nh);
+
+    const msg = {data: 'This shouldn\'t crash'};
+
+    interval1 = setInterval(() => {
+      if (pub) {
+        pub.publish(msg, -1);
+      }
+    }, 3);
+
+    interval2 = setInterval(() => {
+      if (pub === null) {
+        startPub(nh);
+      }
+      else {
+        stopPub();
+      }
+    }, 10);
+
+    setTimeout(done, 8000);
+  });
+
+  it('Pub Sub Shutdown', (done) => {
+    const nh = rosnodejs.nh;
+
+    const msg = {data: 'This shouldn\'t crash'};
+
+    interval1 = setInterval(() => {
+      if (pub) {
+        pub.publish(msg);
+      }
+    }, 3);
+
+    interval2 = setInterval(() => {
+      if (pub === null) {
+        startPub(nh);
+      }
+      else {
+        stopPub();
+      }
+    }, 10);
+
+    interval3 = setInterval(() => {
+      if (sub === null) {
+        startSub(nh);
+      }
+      else {
+        stopSub();
+      }
+    }, 7);
+
+    setTimeout(done, 8000);
+  });
+
+  it('Service Shutdown', (done) => {
+    const nh = rosnodejs.nh;
+    const client = startClient(nh);
+
+    const req = {};
+
+    interval1 = setInterval(() => {
+      client.call(req);
+    }, 3);
+
+    interval2 = setInterval(() => {
+      if (service === null) {
+        startService(nh);
+      }
+      else {
+        stopService();
+      }
+    }, 10);
+
+    setTimeout(done, 8000);
+  });
+
+  it('Client Shutdown', (done) => {
+    const nh = rosnodejs.nh;
+    startService(nh);
+
+    const req = {};
+
+    interval1 = setInterval(() => {
+      if (client) {
+        client.call(req);
+      }
+    }, 1);
+
+    interval2 = setInterval(() => {
+      if (client === null) {
+        startClient(nh);
+      }
+      else {
+        stopClient();
+      }
+    }, 10);
+
+    setTimeout(done, 8000);
+  });
+
+  it('Client Service Shutdown', (done) => {
+    const nh = rosnodejs.nh;
+
+    const req = {};
+
+    interval1 = setInterval(() => {
+      if (client) {
+        client.call(req);
+      }
+    }, 1);
+
+    interval2 = setInterval(() => {
+      if (client === null) {
+        startClient(nh);
+      }
+      else {
+        stopClient();
+      }
+    }, 10);
+
+    interval3 = setInterval(() => {
+      if (service === null) {
+        startService(nh);
+      }
+      else {
+        stopService();
+      }
+    }, 10);
+
+    setTimeout(done, 8000);
+  });
+
+});

--- a/test/Log.js
+++ b/test/Log.js
@@ -49,7 +49,7 @@ describe('Logging', () => {
   });
 
   after(()=> {
-    rosnodejs.log.setLevel('fatal')
+    rosnodejs.reset();
   });
 
   it('Levels', () => {
@@ -283,6 +283,7 @@ describe('Logging', () => {
   describe('Rosout', () => {
     let masterStub;
     before((done) => {
+      rosnodejs.reset();
       masterStub = xmlrpc.createServer({host: 'localhost', port: MASTER_PORT}, () => { done(); });
     });
 
@@ -347,8 +348,8 @@ describe('Logging', () => {
         callback(null, resp);
       });
 
-      rosnodejs.log.setLevel('info');
-      return rosnodejs.initNode('/testNode', {logging: {testing: true},
+      // rosnodejs.log.setLevel('info');
+      return rosnodejs.initNode('/testNode', {logging: {waitOnRosOut: false, level: 'info'},
                                 rosMasterUri: `http://localhost:${MASTER_PORT}`});
     });
 
@@ -373,6 +374,7 @@ describe('Logging', () => {
       let intervalId = null;
 
       const rosoutCallback = (msg) => {
+        console.log('ros out %j', msg);
         expect(msg.msg).to.have.string(message);
         if (intervalId !== null) {
           nh.unsubscribe('/rosout');

--- a/test/directory.js
+++ b/test/directory.js
@@ -1,4 +1,4 @@
-require('./Log.js');
 require('./DeserializeStream.js');
 require('./SpinnerTest.js');
 require('./xmlrpcTest.js');
+require('./Log.js');

--- a/test/stress.js
+++ b/test/stress.js
@@ -349,7 +349,7 @@ describe('ClientShutdown', function() {
       else {
         stopService();
       }
-    }, 10);
+    }, 7);
 
     setTimeout(done, 8000);
   });

--- a/test/xmlrpcTest.js
+++ b/test/xmlrpcTest.js
@@ -32,7 +32,7 @@ describe('Protocol Test', () => {
         callback(null, resp);
       });
 
-      return rosnodejs.initNode(nodeName, {rosMasterUri: `http://localhost:MASTER_PORT`});
+      return rosnodejs.initNode(nodeName, {rosMasterUri: `http://localhost:${MASTER_PORT}`});
     });
 
     afterEach(() => {
@@ -478,7 +478,8 @@ describe('Protocol Test', () => {
           callback(null, resp);
         }
         else {
-          callback(new Error("Missing!"), null);
+          const resp = [-1, "no provider", ""];
+          callback(null, resp);
         }
       });
 

--- a/test/xmlrpcTest.js
+++ b/test/xmlrpcTest.js
@@ -4,10 +4,17 @@ const net = require('net');
 const chai = require('chai');
 const expect = chai.expect;
 const rosnodejs = require('../index.js');
+const Subscriber = require('../lib/Subscriber.js');
 const xmlrpc = require('xmlrpc');
 const netUtils = require('../utils/network_utils.js');
 
 const MASTER_PORT = 11234;
+
+// helper function to throw errors outside a promise scope
+// so they actually trigger failures
+function throwNext(msg) {
+  process.nextTick(() => { throw new Error(msg)});
+}
 
 describe('Protocol Test', () => {
   // NOTE: make sure a roscore is not running (or something else at this address)
@@ -32,7 +39,7 @@ describe('Protocol Test', () => {
         callback(null, resp);
       });
 
-      return rosnodejs.initNode(nodeName, {rosMasterUri: `http://localhost:${MASTER_PORT}`});
+      return rosnodejs.initNode(nodeName, {rosMasterUri: `http://localhost:${MASTER_PORT}`, logging: {skipRosLogging: true}});
     });
 
     afterEach(() => {
@@ -337,6 +344,8 @@ describe('Protocol Test', () => {
       const nh = rosnodejs.nh;
       const sub = nh.subscribe(topic, 'std_msgs/String');
 
+      // NOTE: you'll see an error logged here - THAT'S OK
+      // WE'RE EXPECTING AN ERROR TO LOG
       const logCapture = {
         write(rec) {
           if (rec.level === rosnodejs.log.levelFromName['error'] &&
@@ -385,7 +394,9 @@ describe('Protocol Test', () => {
       });
     });
 
-    it('Throttle Pub', (done) => {
+    it('Throttle Pub', function(done) {
+      this.slow(1000);
+
       const nh = rosnodejs.nh;
       const valsToSend = [1,2,3,4,5,6,7,8,9,10];
       const pub = nh.advertise(topic, msgType, { queueSize: 1, throttleMs: 100});
@@ -415,7 +426,7 @@ describe('Protocol Test', () => {
         expect(pub.getNumSubscribers()).to.equal(1);
         expect(sub.getNumPublishers()).to.equal(1);
 
-        pub.disconnect();
+        pub.shutdown();
 
         expect(pub.getNumSubscribers()).to.equal(0);
         sub.on('disconnect', () => {
@@ -434,7 +445,7 @@ describe('Protocol Test', () => {
         expect(pub.getNumSubscribers()).to.equal(1);
         expect(sub.getNumPublishers()).to.equal(1);
 
-        sub.disconnect();
+        sub.shutdown();
 
         expect(sub.getNumPublishers()).to.equal(0);
         pub.on('disconnect', () => {
@@ -444,6 +455,111 @@ describe('Protocol Test', () => {
       });
 
       pub.on('connection', () => { pub.publish({data: 1}); });
+    });
+
+    it('Shutdown Subscriber During Registration', function(done) {
+      this.slow(1600);
+      const nh = rosnodejs.nh;
+      const sub = nh.subscribe(topic, msgType);
+
+      sub.on('registered', () => {
+        throwNext('Subscriber should never have registered!');
+      });
+
+      sub.shutdown();
+
+      // if we haven't seen the 'registered' event by now we should be good
+      setTimeout(done, 500);
+    });
+
+    it('Shutdown Subscriber Requesting Topic', function(done) {
+      this.slow(1600);
+      const nh = rosnodejs.nh;
+      const pub = nh.advertise(topic, msgType);
+
+      pub.on('registered', () => {
+        const sub = nh.subscribe(topic, msgType);
+        sub.on('registered', () => {
+          sub.shutdown();
+        });
+        sub.on('connection', () => {
+          throwNext('Sub should not have gotten connection');
+        })
+      });
+
+      // if we haven't seen thrown by now we should be good
+      setTimeout(done, 500);
+    });
+
+    it('Shutdown Subscriber Connecting to Publisher', function(done) {
+      this.slow(1600);
+      const nh = rosnodejs.nh;
+      // manually construct a subscriber...
+      const sub = new Subscriber({
+        topic,
+        type: 'std_msgs/String',
+        typeClass: rosnodejs.require('std_msgs').msg.String
+      },nh._node);
+
+      const SOCKET_CONNECT_CACHED = net.Socket.prototype.connect;
+      const SOCKET_END_CACHED = net.Socket.prototype.end;
+
+      sub.on('registered', () => {
+
+        net.Socket.prototype.connect = function(port, address, callback) {
+          process.nextTick(() => {
+            callback();
+          });
+        };
+
+        net.Socket.prototype.end = function() {
+          process.nextTick(() => {
+            net.Socket.prototype.connect = SOCKET_CONNECT_CACHED;
+            net.Socket.prototype.end = SOCKET_END_CACHED;
+
+            done();
+          });
+
+          // even though we didn't actually connect, this socket seems to make
+          // the suite hang unless we call the actual Socket.prototype.end()
+          SOCKET_END_CACHED.call(this);
+        };
+
+        sub._handleTopicRequestResponse([1, 'ok', ['TCPROS', 'junk_address', 1234]], 'http://junk_address:1234');
+        sub.shutdown();
+      });
+    });
+
+    it('Shutdown Publisher During Registration', function(done) {
+      this.slow(1600);
+      const nh = rosnodejs.nh;
+      const pub = nh.advertise(topic, msgType);
+
+      pub.on('registered', () => {
+        throwNext('Publisher should never have registered!');
+      });
+
+      pub.shutdown();
+
+      // if we haven't seen the 'registered' event by now we should be good
+      setTimeout(done, 500);
+    });
+
+    it('Shutdown Publisher With Queued Message', function(done) {
+      this.slow(1600);
+      const nh = rosnodejs.nh;
+      const sub = nh.subscribe(topic, msgType, () => {
+        throwNext('Subscriber should never have gotten messages!');
+      });
+      let pub = nh.advertise(topic, msgType);
+
+      pub.on('connected', () => {
+        pub.publish({data: 1});
+        pub.shutdown();
+      });
+
+      // if we haven't received a message by now we should be good
+      setTimeout(done, 500);
     });
   });
 
@@ -467,7 +583,7 @@ describe('Protocol Test', () => {
       });
 
       masterStub.on('unregisterService', (err, params, callback) => {
-        const resp = [1, 'You did it!', subInfo ? 1 : 0];
+        const resp = [1, 'You did it!', serviceInfo ? 1 : 0];
         callback(null, resp);
         serviceInfo = null;
       });
@@ -513,7 +629,7 @@ describe('Protocol Test', () => {
         done();
       })
       .catch((err) => {
-        throw err;
+        throwNext(err);
       })
     });
 
@@ -529,7 +645,7 @@ describe('Protocol Test', () => {
         return client.call({});
       })
       .then(() => {
-        console.error('Service call succeeded when it shouldn\'t have');
+        throwNext('Service call succeeded when it shouldn\'t have');
       })
       .catch((err) => {
         if (err.code === 'E_ROSSERVICEFAILED') {
@@ -539,6 +655,51 @@ describe('Protocol Test', () => {
           console.error('Service call failed with unexpected error');
         }
       });
+    });
+
+    it('Service Shutdown While Registering', function (done) {
+      this.slow(1600);
+
+      const nh = rosnodejs.nh;
+      const serv = nh.advertiseService(service, srvType, (req, resp) => {
+        return true;
+      });
+
+      // hook into registered event - this should not fire
+      serv.on('registered', () => {
+        throw new Error('Service should never have registered!');
+      });
+
+      // kill the service while the asynchronous registration is happening
+      serv.shutdown();
+
+      // if we haven't seen the 'registered' event by now we should be good
+      setTimeout(done, 500);
+    });
+
+    it('Service Shutdown During Call', function(done) {
+      this.slow(1600);
+
+      const nh = rosnodejs.nh;
+      const serv = nh.advertiseService(service, srvType, (req, resp) => {
+        throw new Error('Service callback should never have been called!');
+      });
+
+      let connected = false;
+      serv.on('connection', () => {
+        // we've received the client header but not the request - SHUT IT DOWN
+        connected = true;
+        serv.shutdown();
+      });
+
+      const client = nh.serviceClient(service, srvType);
+      nh.waitForService(service)
+      .then(() => {
+        client.call({});
+      });
+
+      // if the service callback hasn't been called by now we should be good
+      setTimeout(done, 500);
     });
 
     it('Service Unregistered During Call', (done) => {


### PR DESCRIPTION
Shiwei found a bug where rosnodejs crashed in the Spinner because a client that had been shutdown tried to queue a message - this adds a number of checks to ensure this state doesn't happen. Also adds tests for specific instances of these bugs and a "stress" test that rapid-fire creates and destroys publishers/subscribers and services/clients.
