### PR TITLE
Use utf8 string serialization; bump version + msgUtils

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rosnodejs",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Native ROS for nodejs",
   "main": "index.js",
   "keywords": [
@@ -29,7 +29,7 @@
     "bunyan": "1.8.1",
     "md5": "2.1.0",
     "moment": "2.12.0",
-    "ros_msg_utils": "RethinkRobotics-opensource/ros_msg_utils#v1.0.0",
+    "ros_msg_utils": "RethinkRobotics-opensource/ros_msg_utils#v1.0.1",
     "walker": "1.0.7",
     "xmlrpc": "chfritz/node-xmlrpc"
   }

--- a/utils/messageGeneration/MessageWriter.js
+++ b/utils/messageGeneration/MessageWriter.js
@@ -95,6 +95,7 @@ function writeRequires(w, spec, isSrv, previousPackages=null, previousDeps=null)
     w.write('const _deserializer = _ros_msg_utils.Deserialize;');
     w.write('const _arrayDeserializer = _deserializer.Array');
     w.write('const _finder = _ros_msg_utils.Find;');
+    w.write('const _getByteLength = _ros_msg_utils.getByteLength');
     previousPackages = new Set();
   }
   if (previousDeps === null) {
@@ -495,7 +496,7 @@ function writeGetMessageSize(w, spec) {
             }
 
             // it's a string array!
-            lineToWrite = `length += 4 + object.${field.name}[i].length;`;
+            lineToWrite = `length += 4 + _getByteLength(object.${field.name}[i]);`;
           }
           else {
             const [pkg, msgType] = field.baseType.split('/');
@@ -528,7 +529,7 @@ function writeGetMessageSize(w, spec) {
           // it's a string!
           // string length consumes 4 bytes in message
           lenConstantLengthFields += 4;
-          lineToWrite = `length += object.${field.name}.length;`
+          lineToWrite = `length += _getByteLength(object.${field.name});`
         }
         else {
           const [pkg, msgType] = field.baseType.split('/');


### PR DESCRIPTION
Update ros_msg_utils for proper utf8 string serialization. Includes
using ros_msg_utils proper byte length func in message generation
scripts.

Also version bump package.json to 1.0.3.

NOTE: Depends on RethinkRobotics-opensource/ros_msg_utils#3 to be merged AND **tagged** first.
