### PR TITLE
Fix Add Operations on Locked Spinner

### DIFF
--- a/test/SpinnerTest.js
+++ b/test/SpinnerTest.js
@@ -122,8 +122,47 @@ describe('Spinner', () => {
           expect(spinner._lockedOpCache.length).to.equal(0);
           expect(spinner._clientCallQueue.length).to.equal(0);
           expect(spinner._clientQueueMap.has(client.id)).to.be.false;
+          handleList = [];
 
-          done();
+          spinner.addClient(client, client.id, 3, 0);
+          spinner.ping(client.id, 'junk');
+
+          expect(spinner._lockedOpCache.length).to.equal(0);
+
+          // lock the queue so the next disconnect is cached
+          spinner._queueLocked = true;
+
+          spinner.disconnect(client.id);
+          spinner.addClient(client, client.id, 3, 0);
+          spinner.ping(client.id, 'junk');
+          spinner.ping(client.id, 'junk');
+
+          expect(spinner._lockedOpCache.length).to.equal(4);
+
+          spinner.once('tick', () => {
+            // things that got in before we locked the spinner
+            expect(handleList.length).to.equal(1);
+            expect(handleList[0].queue.length).to.equal(1);
+            expect(spinner._lockedOpCache.length).to.equal(0);
+            expect(spinner._clientCallQueue.length).to.equal(1);
+            expect(spinner._clientQueueMap.has(client.id)).to.be.true;
+            handleList = [];
+
+            // things that got in after we locked the spinner
+            spinner.once('tick', () => {
+              expect(handleList.length).to.equal(1);
+              expect(handleList[0].queue.length).to.equal(2);
+              expect(spinner._lockedOpCache.length).to.equal(0);
+              expect(spinner._clientCallQueue.length).to.equal(0);
+              expect(spinner._clientQueueMap.has(client.id)).to.be.true;
+
+              spinner.disconnect(client.id);
+
+              expect(spinner._clientQueueMap.has(client.id)).to.be.false;
+
+              done();
+            });
+          });
         });
       });
     });
@@ -144,7 +183,7 @@ describe('Spinner', () => {
         if (spinner._clientCallQueue.length === 0) {
           const lastTick = Date.now();
           const tDiff = lastTick - firstTick;
-          expect(tDiff).to.be.at.least(throttleMs);
+          expect(tDiff).to.be.at.least(throttleMs - 1);
 
           done();
         }


### PR DESCRIPTION
-Forgot to cache addClient calls on GlobalSpinner
when queue was locked.
-Added tests for this case.
